### PR TITLE
Fixed numpy chained indexing bug

### DIFF
--- a/zogy.py
+++ b/zogy.py
@@ -8705,7 +8705,9 @@ def flux_optimal_iter (P, D, bkg_var, mask_use, nsigma_inn, nsigma_out,
                     idx_limfrac = idx_sort[mask_use_inn][:npix_limfrac]
 
                     # update inner mask_rej
-                    mask_rej[mask_inn][idx_limfrac] = True
+                    inner_indices = np.where(mask_inn)[0]
+                    mask_rej[mask_inn] = False # reset mask
+                    mask_rej[inner_indices[idx_limfrac]] = True
 
                     if False:
                         log.warning (


### PR DESCRIPTION
Due to an indexing bug, a copy of the mask was updated instead of the mask_rej itself. This resulted in no pixels being discarded in the optimal photometry for sources with S/N <= 100 with too many outlier pixels, rather than rejecting the fraction of pixels with the highest deviation. This bug caused (seeing-dependent) jumps in light curves.